### PR TITLE
Correctly serialize UUIDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 *.egg-info/
 .ipynb_checkpoints
 __pycache__
+.tox

--- a/jupyterlab_sql/handlers/__init__.py
+++ b/jupyterlab_sql/handlers/__init__.py
@@ -6,6 +6,8 @@ from tornado.escape import json_decode
 
 from sqlalchemy import create_engine
 
+from .serializer import make_row_serializable
+
 
 class SqlHandler(IPythonHandler):
     def __init__(self, *args, **kwargs):
@@ -21,7 +23,7 @@ class SqlHandler(IPythonHandler):
             result = connection.execute(query)
             if result.returns_rows:
                 keys = result.keys()
-                rows = [tuple(row) for row in result]
+                rows = [make_row_serializable(row) for row in result]
                 response = {
                     "responseType": "success",
                     "responseData": {

--- a/jupyterlab_sql/handlers/serializer.py
+++ b/jupyterlab_sql/handlers/serializer.py
@@ -1,0 +1,24 @@
+import uuid
+
+
+def make_row_serializable(row):
+    return tuple(_make_value_serializable(value) for value in row)
+
+
+def _make_value_serializable(value):
+    type_ = type(value)
+    processor = DISPATCHER.get(type_)
+    if processor is not None:
+        return processor(value)
+    else:
+        return value
+
+
+def _uuid_processor(uuid):
+    return str(uuid)
+
+
+DISPATCHER = {
+    uuid.UUID: _uuid_processor
+}
+

--- a/jupyterlab_sql/tests/handlers/test_serializer.py
+++ b/jupyterlab_sql/tests/handlers/test_serializer.py
@@ -1,8 +1,23 @@
 
+import uuid
+
+import pytest
+
 from jupyterlab_sql.handlers.serializer import make_row_serializable
 
-def test_make_row_serializable():
-    inp = (1, 'hello')
-    out = (1, 'hello')
-    assert make_row_serializable(inp) == out
-     
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        ((1, 'hello'),),
+        ((1, {'some': 'dict'}),),
+        ((1, {'some': ['array', 'in', 'dict']}),)
+    ])
+def test_make_row_serializable_unchanged(test_input):
+    assert make_row_serializable(test_input) == test_input
+
+
+def test_serialize_uuid():
+    uuid_str = '6e1d16e3-ca00-4e96-9735-95bf92a8c46c'
+    row = (1, uuid.UUID(uuid_str))
+    assert make_row_serializable(row) == (1, uuid_str)

--- a/jupyterlab_sql/tests/handlers/test_serializer.py
+++ b/jupyterlab_sql/tests/handlers/test_serializer.py
@@ -1,0 +1,8 @@
+
+from jupyterlab_sql.handlers.serializer import make_row_serializable
+
+def test_make_row_serializable():
+    inp = (1, 'hello')
+    out = (1, 'hello')
+    assert make_row_serializable(inp) == out
+     

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setuptools.setup(
     version="0.1.0",
     packages=setuptools.find_packages(),
     install_requires=[
-        "jupyterlab"
+        "jupyterlab",
+        "sqlalchemy"
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27, py35, py36, py37
+
+[testenv]
+sitepackages = False
+deps =
+    pytest
+commands = pytest {posargs}


### PR DESCRIPTION
Prior to this PR, UUIDs in a postgres database caused the server to crash. Now fixed.