### PR TITLE
Simplify editing connection string

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,14 +36,16 @@
     "@phosphor/datagrid": "^0.1.6",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
+    "classnames": "^2.2.6",
     "react": "~16.4.2",
     "react-dom": "~16.4.2",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "@types/classnames": "^2.2.7",
+    "@types/uuid": "^3.4.4",
     "rimraf": "^2.6.1",
-    "typescript": "~3.1.1",
-    "@types/uuid": "^3.4.4"
+    "typescript": "~3.1.1"
   },
   "jupyterlab": {
     "extension": true

--- a/style/index.css
+++ b/style/index.css
@@ -64,7 +64,7 @@
     padding-right: 8px;
 }
 
-.p-Sql-ConnectionInformation-input-wrapper.p-Sql-ConnectionInformation-input-wrapper-editing {
+.p-Sql-ConnectionInformation-input-wrapper.p-mod-focused {
     border: 1px solid var(--md-blue-500);
     box-shadow: inset 0 0 4px var(--md-blue-300);
 }
@@ -76,20 +76,6 @@
     color: var(--jp-ui-font-color1);
     font-weight: 400;
     overflow: hidden;
-}
-
-.p-Sql-ConnectionInformation-edit-button {
-    background-image: var(--jp-icon-edit);
-    background-size: 20px;
-    background-repeat: no-repeat;
-    background-position: center;
-    border-right: 1px solid var(--jp-border-color0);
-    border-top: 1px solid var(--jp-border-color0);
-    border-bottom: 1px solid var(--jp-border-color0);
-    width: 30px;
-    height: 30px;
-    display: inline-block;
-    vertical-align: middle;
 }
 
 .p-Sql-ConnectionInformation-input {

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,6 +271,11 @@
     "@phosphor/signaling" "^1.2.2"
     "@phosphor/virtualdom" "^1.1.2"
 
+"@types/classnames@^2.2.7":
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.7.tgz#fb68cc9be8487e6ea5b13700e759bfbab7e0fefd"
+  integrity sha512-rzOhiQ55WzAiFgXRtitP/ZUT8iVNyllEpylJ5zHzR4vArUvMB39GTk+Zon/uAM0JxEFAWnwsxC2gH8s+tZ3Myg==
+
 "@types/node@*":
   version "10.12.24"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.24.tgz#b13564af612a22a20b5d95ca40f1bffb3af315cf"
@@ -338,6 +343,11 @@ chalk@^2.3.0, chalk@^2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 co@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
The connection string is now just a plain text box, instead of having a dual edit/display mode. This simplifies the UX somewhat.