### PR TITLE
Allow `%` in statements

### DIFF
--- a/jupyterlab_sql/handlers/__init__.py
+++ b/jupyterlab_sql/handlers/__init__.py
@@ -16,7 +16,11 @@ class SqlHandler(IPythonHandler):
 
     def execute_query(self, engine, query):
         connection = engine.connect()
-        result = connection.execute(query)
+        result = (
+            connection
+            .execution_options(no_parameters=True)
+            .execute(query)
+        )
         return result
 
     async def post(self):


### PR DESCRIPTION
Now statements like `select * from account where email like '%john%'` work.