### PR TITLE
Make connection bar take full width

### DIFF
--- a/src/toolbar.tsx
+++ b/src/toolbar.tsx
@@ -138,27 +138,21 @@ class ConnectionInformationEdit extends React.Component<
 
   render() {
     const { value, focused } = this.state;
-    const wrapperClass = classNames(
-      'p-Sql-ConnectionInformation-wrapper',
-      { 'p-mod-focused': focused }
-    );
     const inputWrapperClass = classNames(
       'p-Sql-ConnectionInformation-input-wrapper',
       { 'p-mod-focused': focused }
     );
     return (
-      <div className={wrapperClass}>
-        <div className={inputWrapperClass}>
-          <input
-            className="p-Sql-ConnectionInformation-text p-Sql-ConnectionInformation-input"
-            value={value}
-            ref={this.inputRef}
-            onChange={event => this.onChange(event)}
-            onKeyDown={event => this.onKeyDown(event)}
-            onBlur={() => this.onInputBlur()}
-            onFocus={() => this.onInputFocus() }
-          />
-        </div>
+      <div className={inputWrapperClass}>
+        <input
+          className="p-Sql-ConnectionInformation-text p-Sql-ConnectionInformation-input"
+          value={value}
+          ref={this.inputRef}
+          onChange={event => this.onChange(event)}
+          onKeyDown={event => this.onKeyDown(event)}
+          onBlur={() => this.onInputBlur()}
+          onFocus={() => this.onInputFocus() }
+        />
       </div>
     )
   }

--- a/style/index.css
+++ b/style/index.css
@@ -14,6 +14,8 @@
     border: 1px solid var(--jp-border-color0);
     width: 30px;
     height: 30px;
+    margin-left: 2px;
+    flex: 0 0 auto;
 }
 
 .p-Sql-LoadingIcon-Spinner {
@@ -57,11 +59,11 @@
 .p-Sql-ConnectionInformation-input-wrapper {
     height: 30px;
     border: 1px solid var(--jp-border-color0);
-    width: 400px;
     display: inline-block;
     vertical-align: middle;
     padding-left: 8px;
     padding-right: 8px;
+    flex: 1 1 auto;
 }
 
 .p-Sql-ConnectionInformation-input-wrapper.p-mod-focused {


### PR DESCRIPTION
This is particularly useful for large connection strings.

<img width="1043" alt="screenshot 2019-02-23 at 11 06 56" src="https://user-images.githubusercontent.com/1392879/53285669-2becc680-375b-11e9-8a85-c30e2b107805.png">

