### PR TITLE
Fix version file template to avoid Black errors

### DIFF
--- a/jupyterlab_sql/version.py
+++ b/jupyterlab_sql/version.py
@@ -1,4 +1,3 @@
-
 # This file is generated programatically.
 # Version of the Python package
-__version__ = "0.1.2"
+__version__ = "0.1.3-dev"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-sql",
-  "version": "0.1.2",
+  "version": "0.1.3-dev",
   "description": "JupyterLab extension for interacting with SQL databases",
   "keywords": [
     "jupyter",

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ NPM_PATH = [
 IS_REPO = (HERE / ".git").exists()
 PYVERSION_PATH = HERE / "jupyterlab_sql" / "version.py"
 
-VERSION_TEMPLATE = """
-# This file is generated programatically.
+VERSION_TEMPLATE = """# This file is generated programatically.
 # Version of the Python package
 __version__ = "{}"
 """


### PR DESCRIPTION
The auto-generated version.py file was not Black compatible. This caused CI failures.