### PR TITLE
Restore state on refresh

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -7,17 +7,24 @@ import {
 import { ISignal, Signal } from '@phosphor/signaling';
 
 export class Editor extends CodeEditorWrapper {
-  constructor(editorFactory: IEditorFactoryService) {
+  constructor(initialValue: string, editorFactory: IEditorFactoryService) {
     super({
-      model: new CodeEditor.Model(),
+      model: new CodeEditor.Model({ value: initialValue }),
       factory: editorFactory.newInlineEditor
     });
     this.editor.addKeydownHandler((_, evt) => this._onKeydown(evt));
     this.addClass('p-Sql-Editor');
+    this.model.value.changed.connect(() => {
+      this._valueChanged.emit(this.model.value.text)
+    })
   }
 
   get executeRequest(): ISignal<this, string> {
     return this._executeRequest;
+  }
+
+  get valueChanged(): ISignal<this, string> {
+    return this._valueChanged;
   }
 
   _onKeydown(event: KeyboardEvent): boolean {
@@ -29,4 +36,5 @@ export class Editor extends CodeEditorWrapper {
   }
 
   private _executeRequest = new Signal<this, string>(this);
+  private _valueChanged = new Signal<this, string>(this);
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -15,8 +15,8 @@ export class Editor extends CodeEditorWrapper {
     this.editor.addKeydownHandler((_, evt) => this._onKeydown(evt));
     this.addClass('p-Sql-Editor');
     this.model.value.changed.connect(() => {
-      this._valueChanged.emit(this.model.value.text)
-    })
+      this._valueChanged.emit(this.model.value.text);
+    });
   }
 
   get executeRequest(): ISignal<this, string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { ILauncher } from '@jupyterlab/launcher';
 
 import { JupyterLabSqlWidget } from './widget';
 
+import { createTracker } from './tracker';
+
 import '../style/index.css';
 
 function activate(
@@ -19,12 +21,7 @@ function activate(
   editorServices: IEditorServices,
   restorer: ILayoutRestorer
 ) {
-  const namespace: string = 'jupyterlab-sql';
-
-  const tracker = new InstanceTracker<MainAreaWidget<JupyterLabSqlWidget>>({
-    namespace
-  });
-
+  const tracker: InstanceTracker<MainAreaWidget<JupyterLabSqlWidget>> = createTracker()
   const command: string = 'jupyterlab-sql:open';
 
   restorer.restore(tracker, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,18 +26,19 @@ function activate(
 
   restorer.restore(tracker, {
     command: command,
-    args: widget => ({ name: widget.content.name }),
+    args: widget => ({ name: widget.content.name, connectionString: widget.content.toolbarModel.connectionString }),
     name: widget => { console.log(widget.content.name); return widget.content.name }
   });
 
   app.commands.addCommand(command, {
     label: ({ isPalette }) => (isPalette ? 'New SQL session' : 'SQL'),
     iconClass: 'p-Sql-DatabaseIcon',
-    execute: ({ name }) => {
+    execute: ({ name, connectionString }) => {
       const widgetName = <string>(name || uuid.v4());
+      const initialConnectionString = <string>(connectionString || "postgres://localhost:5432/postgres")
       const widget = new JupyterLabSqlWidget(
         editorServices.factoryService,
-        { name: widgetName, initialConnectionString: "postgres://localhost:5432/postgres" }
+        { name: widgetName, initialConnectionString }
       );
       const main = new MainAreaWidget({ content: widget })
       app.shell.addToMainArea(main);

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,16 +24,23 @@ import { ResponseWidget } from './response';
 
 import '../style/index.css';
 
+namespace JupyterLabSqlWidget {
+  export interface Options {
+    name: string;
+    initialConnectionString: string;
+  }
+}
+
 class JupyterLabSqlWidget extends BoxPanel {
-  constructor(name: string, editorFactory: IEditorFactoryService) {
+  constructor(editorFactory: IEditorFactoryService, options: JupyterLabSqlWidget.Options) {
     super();
-    this.name = name;
+    this.name = options.name;
     this.id = 'jupyterlab-sql';
     this.title.label = 'SQL';
     this.title.closable = true;
     this.addClass('p-Sql-MainContainer');
 
-    this.toolbarModel = new ToolbarModel();
+    this.toolbarModel = new ToolbarModel(options.initialConnectionString);
     const connectionWidget = new ToolbarContainer();
     connectionWidget.model = this.toolbarModel;
 
@@ -117,7 +124,8 @@ function activate(
     execute: ({ name }) => {
       const widgetName = <string>(name || uuid.v4());
       const widget = new JupyterLabSqlWidget(
-        widgetName, editorServices.factoryService
+        editorServices.factoryService,
+        { name: widgetName, initialConnectionString: "postgres://localhost:5432/postgres" }
       );
       const main = new MainAreaWidget({ content: widget })
       app.shell.addToMainArea(main);

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,19 +26,20 @@ function activate(
 
   restorer.restore(tracker, {
     command: command,
-    args: widget => ({ name: widget.content.name, connectionString: widget.content.toolbarModel.connectionString }),
+    args: widget => ({ name: widget.content.name, connectionString: widget.content.toolbarModel.connectionString, sqlStatement: widget.content.sqlStatementValue }),
     name: widget => { console.log(widget.content.name); return widget.content.name }
   });
 
   app.commands.addCommand(command, {
     label: ({ isPalette }) => (isPalette ? 'New SQL session' : 'SQL'),
     iconClass: 'p-Sql-DatabaseIcon',
-    execute: ({ name, connectionString }) => {
+    execute: ({ name, connectionString, sqlStatement }) => {
       const widgetName = <string>(name || uuid.v4());
       const initialConnectionString = <string>(connectionString || "postgres://localhost:5432/postgres")
+      const initialSqlStatement = <string>(sqlStatement || "");
       const widget = new JupyterLabSqlWidget(
         editorServices.factoryService,
-        { name: widgetName, initialConnectionString }
+        { name: widgetName, initialConnectionString, initialSqlStatement }
       );
       const main = new MainAreaWidget({ content: widget })
       app.shell.addToMainArea(main);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as uuid from 'uuid';
 
 import { JupyterLab, JupyterLabPlugin } from '@jupyterlab/application';
 
-import { ICommandPalette } from '@jupyterlab/apputils';
+import { ICommandPalette, MainAreaWidget } from '@jupyterlab/apputils';
 
 import { IEditorFactoryService, IEditorServices } from '@jupyterlab/codeeditor';
 
@@ -13,6 +13,7 @@ import { BoxPanel } from '@phosphor/widgets';
 import { Message } from '@phosphor/messaging';
 
 import { ServerConnection } from '@jupyterlab/services';
+
 import { URLExt } from '@jupyterlab/coreutils';
 
 import { Editor } from './editor';
@@ -98,12 +99,11 @@ function activate(
     label: ({ isPalette }) => (isPalette ? 'New SQL session' : 'SQL'),
     iconClass: 'p-Sql-DatabaseIcon',
     execute: () => {
-      const widget: JupyterLabSqlWidget = new JupyterLabSqlWidget(
+      const widget = new JupyterLabSqlWidget(
         editorServices.factoryService
       );
-      app.shell.addToMainArea(widget);
-      widget.update();
-      app.shell.activateById(widget.id);
+      const main = new MainAreaWidget({ content: widget })
+      app.shell.addToMainArea(main);
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,16 @@
 import * as uuid from 'uuid';
 
-import { JupyterLab, JupyterLabPlugin, ILayoutRestorer } from '@jupyterlab/application';
+import {
+  JupyterLab,
+  JupyterLabPlugin,
+  ILayoutRestorer
+} from '@jupyterlab/application';
 
-import { ICommandPalette, MainAreaWidget, InstanceTracker } from '@jupyterlab/apputils';
+import {
+  ICommandPalette,
+  MainAreaWidget,
+  InstanceTracker
+} from '@jupyterlab/apputils';
 
 import { IEditorServices } from '@jupyterlab/codeeditor';
 
@@ -21,12 +29,18 @@ function activate(
   editorServices: IEditorServices,
   restorer: ILayoutRestorer
 ) {
-  const tracker: InstanceTracker<MainAreaWidget<JupyterLabSqlWidget>> = createTracker()
+  const tracker: InstanceTracker<
+    MainAreaWidget<JupyterLabSqlWidget>
+  > = createTracker();
   const command: string = 'jupyterlab-sql:open';
 
   restorer.restore(tracker, {
     command: command,
-    args: widget => ({ name: widget.content.name, connectionString: widget.content.toolbarModel.connectionString, sqlStatement: widget.content.sqlStatementValue }),
+    args: widget => ({
+      name: widget.content.name,
+      connectionString: widget.content.toolbarModel.connectionString,
+      sqlStatement: widget.content.sqlStatementValue
+    }),
     name: widget => widget.content.name
   });
 
@@ -35,15 +49,18 @@ function activate(
     iconClass: 'p-Sql-DatabaseIcon',
     execute: ({ name, connectionString, sqlStatement }) => {
       const widgetName = <string>(name || uuid.v4());
-      const initialConnectionString = <string>(connectionString || "postgres://localhost:5432/postgres")
-      const initialSqlStatement = <string>(sqlStatement || "");
-      const widget = new JupyterLabSqlWidget(
-        editorServices.factoryService,
-        { name: widgetName, initialConnectionString, initialSqlStatement }
+      const initialConnectionString = <string>(
+        (connectionString || 'postgres://localhost:5432/postgres')
       );
-      const main = new MainAreaWidget({ content: widget })
+      const initialSqlStatement = <string>(sqlStatement || '');
+      const widget = new JupyterLabSqlWidget(editorServices.factoryService, {
+        name: widgetName,
+        initialConnectionString,
+        initialSqlStatement
+      });
+      const main = new MainAreaWidget({ content: widget });
       app.shell.addToMainArea(main);
-      tracker.add(main)
+      tracker.add(main);
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ function activate(
   restorer.restore(tracker, {
     command: command,
     args: widget => ({ name: widget.content.name, connectionString: widget.content.toolbarModel.connectionString, sqlStatement: widget.content.sqlStatementValue }),
-    name: widget => { console.log(widget.content.name); return widget.content.name }
+    name: widget => widget.content.name
   });
 
   app.commands.addCommand(command, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,98 +4,13 @@ import { JupyterLab, JupyterLabPlugin, ILayoutRestorer } from '@jupyterlab/appli
 
 import { ICommandPalette, MainAreaWidget, InstanceTracker } from '@jupyterlab/apputils';
 
-import { IEditorFactoryService, IEditorServices } from '@jupyterlab/codeeditor';
+import { IEditorServices } from '@jupyterlab/codeeditor';
 
 import { ILauncher } from '@jupyterlab/launcher';
 
-import { BoxPanel } from '@phosphor/widgets';
-
-import { Message } from '@phosphor/messaging';
-
-import { ServerConnection } from '@jupyterlab/services';
-
-import { URLExt } from '@jupyterlab/coreutils';
-
-import { Editor } from './editor';
-
-import { ToolbarContainer, ToolbarModel } from './toolbar';
-
-import { ResponseWidget } from './response';
+import { JupyterLabSqlWidget } from './widget';
 
 import '../style/index.css';
-
-namespace JupyterLabSqlWidget {
-  export interface Options {
-    name: string;
-    initialConnectionString: string;
-  }
-}
-
-class JupyterLabSqlWidget extends BoxPanel {
-  constructor(editorFactory: IEditorFactoryService, options: JupyterLabSqlWidget.Options) {
-    super();
-    this.name = options.name;
-    this.id = 'jupyterlab-sql';
-    this.title.label = 'SQL';
-    this.title.closable = true;
-    this.addClass('p-Sql-MainContainer');
-
-    this.toolbarModel = new ToolbarModel(options.initialConnectionString);
-    const connectionWidget = new ToolbarContainer();
-    connectionWidget.model = this.toolbarModel;
-
-    this.editorWidget = new Editor(editorFactory);
-    this.responseWidget = new ResponseWidget();
-
-    this.editorWidget.executeRequest.connect((_, value) => {
-      const connectionString = this.toolbarModel.connectionString;
-      this.updateGrid(connectionString, value);
-    });
-    this.settings = ServerConnection.makeSettings();
-
-    this.addWidget(connectionWidget);
-    this.addWidget(this.editorWidget);
-    this.addWidget(this.responseWidget);
-    BoxPanel.setSizeBasis(connectionWidget, 50);
-    BoxPanel.setStretch(this.editorWidget, 1);
-    BoxPanel.setStretch(this.responseWidget, 3);
-  }
-
-  readonly editorFactory: IEditorFactoryService;
-  readonly editorWidget: Editor;
-  readonly settings: ServerConnection.ISettings;
-  readonly responseWidget: ResponseWidget;
-  readonly toolbarModel: ToolbarModel;
-  readonly name: string;
-  private _lastRequestId: string;
-
-  async updateGrid(connectionString: string, sql: string): Promise<void> {
-    const url = URLExt.join(this.settings.baseUrl, '/jupyterlab-sql/query');
-    const request: RequestInit = {
-      method: 'POST',
-      body: JSON.stringify({ connectionString, query: sql })
-    };
-    const thisRequestId = uuid.v4();
-    this._lastRequestId = thisRequestId;
-    this.toolbarModel.isLoading = true;
-    const response = await ServerConnection.makeRequest(
-      url,
-      request,
-      this.settings
-    );
-    const data = await response.json();
-    if (this._lastRequestId === thisRequestId) {
-      // Only update the response widget if the current
-      // query is the last query that was dispatched.
-      this.responseWidget.setResponse(data);
-    }
-    this.toolbarModel.isLoading = false;
-  }
-
-  onActivateRequest(msg: Message) {
-    this.editorWidget.activate();
-  }
-}
 
 function activate(
   app: JupyterLab,

--- a/src/toolbar.tsx
+++ b/src/toolbar.tsx
@@ -1,3 +1,5 @@
+import { ISignal, Signal } from '@phosphor/signaling';
+
 import { VDomModel, VDomRenderer } from '@jupyterlab/apputils';
 
 import * as React from 'react';
@@ -13,6 +15,11 @@ export class ToolbarModel extends VDomModel {
 
   private _connectionString: string;
   private _isLoading: boolean = false;
+  private _connectionStringChanged = new Signal<this, string>(this);
+
+  get connectionStringChanged(): ISignal<this, string> {
+    return this._connectionStringChanged;
+  }
 
   get connectionString(): string {
     return this._connectionString;
@@ -25,6 +32,7 @@ export class ToolbarModel extends VDomModel {
   set connectionString(newString: string) {
     this._connectionString = newString;
     this.stateChanged.emit(void 0);
+    this._connectionStringChanged.emit(newString);
   }
 
   set isLoading(newValue: boolean) {

--- a/src/toolbar.tsx
+++ b/src/toolbar.tsx
@@ -7,7 +7,6 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 export class ToolbarModel extends VDomModel {
-
   constructor(initialConnectionString: string) {
     super();
     this._connectionString = initialConnectionString;

--- a/src/toolbar.tsx
+++ b/src/toolbar.tsx
@@ -5,7 +5,13 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 export class ToolbarModel extends VDomModel {
-  private _connectionString: string = 'postgres://localhost:5432/postgres';
+
+  constructor(initialConnectionString: string) {
+    super();
+    this._connectionString = initialConnectionString;
+  }
+
+  private _connectionString: string;
   private _isLoading: boolean = false;
 
   get connectionString(): string {

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -16,8 +16,8 @@ export function createTracker(): InstanceTracker<MainAreaWidget<JupyterLabSqlWid
   });
 
   tracker.widgetAdded.connect((_, widget) => {
-    widget.content.onConnectionStringChanged.connect((_, value: string) => {
-      console.log(value)
+    widget.content.onConnectionStringChanged.connect(() => {
+      tracker.save(widget)
     });
   })
 

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -1,14 +1,10 @@
+import { MainAreaWidget, InstanceTracker } from '@jupyterlab/apputils';
 
-import {
-  MainAreaWidget, InstanceTracker
-} from '@jupyterlab/apputils';
+import { JupyterLabSqlWidget } from './widget';
 
-import {
-  JupyterLabSqlWidget
-} from './widget';
-
-
-export function createTracker(): InstanceTracker<MainAreaWidget<JupyterLabSqlWidget>> {
+export function createTracker(): InstanceTracker<
+  MainAreaWidget<JupyterLabSqlWidget>
+> {
   const namespace: string = 'jupyterlab-sql';
 
   const tracker = new InstanceTracker<MainAreaWidget<JupyterLabSqlWidget>>({
@@ -17,12 +13,12 @@ export function createTracker(): InstanceTracker<MainAreaWidget<JupyterLabSqlWid
 
   tracker.widgetAdded.connect((_, widget) => {
     widget.content.connectionStringChanged.connect(() => {
-      tracker.save(widget)
+      tracker.save(widget);
     });
     widget.content.sqlStatementChanged.connect(() => {
-      tracker.save(widget)
-    })
-  })
+      tracker.save(widget);
+    });
+  });
 
   return tracker;
 }

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -16,7 +16,9 @@ export function createTracker(): InstanceTracker<MainAreaWidget<JupyterLabSqlWid
   });
 
   tracker.widgetAdded.connect((_, widget) => {
-    console.log("hello widget!")
+    widget.content.onConnectionStringChanged.connect((_, value: string) => {
+      console.log(value)
+    });
   })
 
   return tracker;

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -1,0 +1,23 @@
+
+import {
+  MainAreaWidget, InstanceTracker
+} from '@jupyterlab/apputils';
+
+import {
+  JupyterLabSqlWidget
+} from './widget';
+
+
+export function createTracker(): InstanceTracker<MainAreaWidget<JupyterLabSqlWidget>> {
+  const namespace: string = 'jupyterlab-sql';
+
+  const tracker = new InstanceTracker<MainAreaWidget<JupyterLabSqlWidget>>({
+    namespace
+  });
+
+  tracker.widgetAdded.connect((_, widget) => {
+    console.log("hello widget!")
+  })
+
+  return tracker;
+}

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -16,7 +16,7 @@ export function createTracker(): InstanceTracker<MainAreaWidget<JupyterLabSqlWid
   });
 
   tracker.widgetAdded.connect((_, widget) => {
-    widget.content.onConnectionStringChanged.connect(() => {
+    widget.content.connectionStringChanged.connect(() => {
       tracker.save(widget)
     });
   })

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -19,6 +19,9 @@ export function createTracker(): InstanceTracker<MainAreaWidget<JupyterLabSqlWid
     widget.content.connectionStringChanged.connect(() => {
       tracker.save(widget)
     });
+    widget.content.sqlStatementChanged.connect(() => {
+      tracker.save(widget)
+    })
   })
 
   return tracker;

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,0 +1,90 @@
+import * as uuid from 'uuid';
+
+import { BoxPanel } from '@phosphor/widgets';
+
+import { Message } from '@phosphor/messaging';
+
+import { IEditorFactoryService } from '@jupyterlab/codeeditor';
+
+import { ServerConnection } from '@jupyterlab/services';
+
+import { URLExt } from '@jupyterlab/coreutils';
+
+import { ToolbarContainer, ToolbarModel } from './toolbar';
+
+import { ResponseWidget } from './response';
+
+import { Editor } from './editor';
+
+namespace JupyterLabSqlWidget {
+  export interface Options {
+    name: string;
+    initialConnectionString: string;
+  }
+}
+
+export class JupyterLabSqlWidget extends BoxPanel {
+  constructor(editorFactory: IEditorFactoryService, options: JupyterLabSqlWidget.Options) {
+    super();
+    this.name = options.name;
+    this.id = 'jupyterlab-sql';
+    this.title.label = 'SQL';
+    this.title.closable = true;
+    this.addClass('p-Sql-MainContainer');
+
+    this.toolbarModel = new ToolbarModel(options.initialConnectionString);
+    const connectionWidget = new ToolbarContainer();
+    connectionWidget.model = this.toolbarModel;
+
+    this.editorWidget = new Editor(editorFactory);
+    this.responseWidget = new ResponseWidget();
+
+    this.editorWidget.executeRequest.connect((_, value) => {
+      const connectionString = this.toolbarModel.connectionString;
+      this.updateGrid(connectionString, value);
+    });
+    this.settings = ServerConnection.makeSettings();
+
+    this.addWidget(connectionWidget);
+    this.addWidget(this.editorWidget);
+    this.addWidget(this.responseWidget);
+    BoxPanel.setSizeBasis(connectionWidget, 50);
+    BoxPanel.setStretch(this.editorWidget, 1);
+    BoxPanel.setStretch(this.responseWidget, 3);
+  }
+
+  readonly editorFactory: IEditorFactoryService;
+  readonly editorWidget: Editor;
+  readonly settings: ServerConnection.ISettings;
+  readonly responseWidget: ResponseWidget;
+  readonly toolbarModel: ToolbarModel;
+  readonly name: string;
+  private _lastRequestId: string;
+
+  async updateGrid(connectionString: string, sql: string): Promise<void> {
+    const url = URLExt.join(this.settings.baseUrl, '/jupyterlab-sql/query');
+    const request: RequestInit = {
+      method: 'POST',
+      body: JSON.stringify({ connectionString, query: sql })
+    };
+    const thisRequestId = uuid.v4();
+    this._lastRequestId = thisRequestId;
+    this.toolbarModel.isLoading = true;
+    const response = await ServerConnection.makeRequest(
+      url,
+      request,
+      this.settings
+    );
+    const data = await response.json();
+    if (this._lastRequestId === thisRequestId) {
+      // Only update the response widget if the current
+      // query is the last query that was dispatched.
+      this.responseWidget.setResponse(data);
+    }
+    this.toolbarModel.isLoading = false;
+  }
+
+  onActivateRequest(msg: Message) {
+    this.editorWidget.activate();
+  }
+}

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -4,6 +4,8 @@ import { BoxPanel } from '@phosphor/widgets';
 
 import { Message } from '@phosphor/messaging';
 
+import { ISignal, Signal } from '@phosphor/signaling';
+
 import { IEditorFactoryService } from '@jupyterlab/codeeditor';
 
 import { ServerConnection } from '@jupyterlab/services';
@@ -36,6 +38,11 @@ export class JupyterLabSqlWidget extends BoxPanel {
     const connectionWidget = new ToolbarContainer();
     connectionWidget.model = this.toolbarModel;
 
+    this.toolbarModel.stateChanged.connect(() => {
+      console.log("state changed")
+      this._connectionStringChanged.emit("hello")
+    })
+
     this.editorWidget = new Editor(editorFactory);
     this.responseWidget = new ResponseWidget();
 
@@ -60,6 +67,11 @@ export class JupyterLabSqlWidget extends BoxPanel {
   readonly toolbarModel: ToolbarModel;
   readonly name: string;
   private _lastRequestId: string;
+  private _connectionStringChanged = new Signal<this, string>(this);
+
+  get onConnectionStringChanged(): ISignal<this, string> {
+    return this._connectionStringChanged
+  }
 
   async updateGrid(connectionString: string, sql: string): Promise<void> {
     const url = URLExt.join(this.settings.baseUrl, '/jupyterlab-sql/query');

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -38,9 +38,8 @@ export class JupyterLabSqlWidget extends BoxPanel {
     const connectionWidget = new ToolbarContainer();
     connectionWidget.model = this.toolbarModel;
 
-    this.toolbarModel.stateChanged.connect(() => {
-      console.log("state changed")
-      this._connectionStringChanged.emit("hello")
+    this.toolbarModel.connectionStringChanged.connect((_, value: string) => {
+      this._connectionStringChanged.emit(value)
     })
 
     this.editorWidget = new Editor(editorFactory);
@@ -69,7 +68,7 @@ export class JupyterLabSqlWidget extends BoxPanel {
   private _lastRequestId: string;
   private _connectionStringChanged = new Signal<this, string>(this);
 
-  get onConnectionStringChanged(): ISignal<this, string> {
+  get connectionStringChanged(): ISignal<this, string> {
     return this._connectionStringChanged
   }
 

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -27,7 +27,10 @@ namespace JupyterLabSqlWidget {
 }
 
 export class JupyterLabSqlWidget extends BoxPanel {
-  constructor(editorFactory: IEditorFactoryService, options: JupyterLabSqlWidget.Options) {
+  constructor(
+    editorFactory: IEditorFactoryService,
+    options: JupyterLabSqlWidget.Options
+  ) {
     super();
     this.name = options.name;
     this.id = 'jupyterlab-sql';
@@ -40,8 +43,8 @@ export class JupyterLabSqlWidget extends BoxPanel {
     connectionWidget.model = this.toolbarModel;
 
     this.toolbarModel.connectionStringChanged.connect((_, value: string) => {
-      this._connectionStringChanged.emit(value)
-    })
+      this._connectionStringChanged.emit(value);
+    });
 
     this.editorWidget = new Editor(options.initialSqlStatement, editorFactory);
     this.responseWidget = new ResponseWidget();
@@ -52,7 +55,7 @@ export class JupyterLabSqlWidget extends BoxPanel {
     });
     this.editorWidget.valueChanged.connect((_, value) => {
       this._sqlStatementChanged.emit(value);
-    })
+    });
     this.settings = ServerConnection.makeSettings();
 
     this.addWidget(connectionWidget);
@@ -74,11 +77,11 @@ export class JupyterLabSqlWidget extends BoxPanel {
   private _sqlStatementChanged = new Signal<this, string>(this);
 
   get connectionStringChanged(): ISignal<this, string> {
-    return this._connectionStringChanged
+    return this._connectionStringChanged;
   }
 
   get sqlStatementChanged(): ISignal<this, string> {
-    return this._sqlStatementChanged
+    return this._sqlStatementChanged;
   }
 
   get sqlStatementValue(): string {


### PR DESCRIPTION
Prior to this PR, on page refreshes the SQL windows would disappear. Now, they are restored, along with:
- the current value of the connection string
- the current value of the SQL statement

The response is not currently tracked.