### PR TITLE
Hide editor behind interface

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -24,12 +24,12 @@ export class Editor implements IEditor {
       this._valueChanged.emit(this.value);
     });
     this._widget.executeCurrent.connect(() => {
-      this._execute.emit(this.value)
+      this._execute.emit(this.value);
     });
   }
 
   get value(): string {
-    return this._model.value.text
+    return this._model.value.text;
   }
 
   get widget(): Widget {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -47,11 +47,11 @@ export class Editor implements IEditor {
   private _execute = new Signal<this, string>(this);
   private _valueChanged = new Signal<this, string>(this);
   private _widget: EditorWidget;
-  private _model: CodeEditor.Model;
+  private _model: CodeEditor.IModel;
 }
 
 export class EditorWidget extends CodeEditorWrapper {
-  constructor(model: CodeEditor.Model, editorFactory: IEditorFactoryService) {
+  constructor(model: CodeEditor.IModel, editorFactory: IEditorFactoryService) {
     super({
       model,
       factory: editorFactory.newInlineEditor

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -12,7 +12,7 @@ import { ToolbarContainer, ToolbarModel } from './toolbar';
 
 import { ResponseWidget } from './response';
 
-import { Editor } from './editor';
+import { Editor, IEditor } from './editor';
 
 import { Api } from './api';
 
@@ -44,27 +44,27 @@ export class JupyterLabSqlWidget extends BoxPanel {
       this._connectionStringChanged.emit(value);
     });
 
-    this.editorWidget = new Editor(options.initialSqlStatement, editorFactory);
+    this.editor = new Editor(options.initialSqlStatement, editorFactory);
     this.responseWidget = new ResponseWidget();
 
-    this.editorWidget.executeRequest.connect((_, value) => {
+    this.editor.execute.connect((_, value: string) => {
       const connectionString = this.toolbarModel.connectionString;
       this.updateGrid(connectionString, value);
     });
-    this.editorWidget.valueChanged.connect((_, value) => {
+    this.editor.valueChanged.connect((_, value) => {
       this._sqlStatementChanged.emit(value);
     });
 
     this.addWidget(connectionWidget);
-    this.addWidget(this.editorWidget);
+    this.addWidget(this.editor.widget);
     this.addWidget(this.responseWidget);
     BoxPanel.setSizeBasis(connectionWidget, 50);
-    BoxPanel.setStretch(this.editorWidget, 1);
+    BoxPanel.setStretch(this.editor.widget, 1);
     BoxPanel.setStretch(this.responseWidget, 3);
   }
 
   readonly editorFactory: IEditorFactoryService;
-  readonly editorWidget: Editor;
+  readonly editor: IEditor;
   readonly responseWidget: ResponseWidget;
   readonly toolbarModel: ToolbarModel;
   readonly name: string;
@@ -81,7 +81,7 @@ export class JupyterLabSqlWidget extends BoxPanel {
   }
 
   get sqlStatementValue(): string {
-    return this.editorWidget.model.value.text;
+    return this.editor.value;
   }
 
   async updateGrid(connectionString: string, sql: string): Promise<void> {
@@ -98,6 +98,6 @@ export class JupyterLabSqlWidget extends BoxPanel {
   }
 
   onActivateRequest(msg: Message) {
-    this.editorWidget.activate();
+    this.editor.widget.activate();
   }
 }


### PR DESCRIPTION
This tidies up the code somewhat by introducing an interface for the editor and coding against it, rather than directly against the class.