### PR TITLE
Support Postgres numeric type

### DIFF
--- a/jupyterlab_sql/handlers/serializer.py
+++ b/jupyterlab_sql/handlers/serializer.py
@@ -37,5 +37,5 @@ DISPATCHER = {
     datetime.datetime: _datetime_processor,
     datetime.date: _datetime_processor,
     list: _list_processor,
-    decimal.Decimal: _decimal_processor
+    decimal.Decimal: _decimal_processor,
 }

--- a/jupyterlab_sql/handlers/serializer.py
+++ b/jupyterlab_sql/handlers/serializer.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+import decimal
 
 
 def make_row_serializable(row):
@@ -27,9 +28,14 @@ def _list_processor(l):
     return [_make_value_serializable(value) for value in l]
 
 
+def _decimal_processor(dec):
+    return str(dec)
+
+
 DISPATCHER = {
     uuid.UUID: _uuid_processor,
     datetime.datetime: _datetime_processor,
     datetime.date: _datetime_processor,
     list: _list_processor,
+    decimal.Decimal: _decimal_processor
 }

--- a/jupyterlab_sql/tests/handlers/test_serializer.py
+++ b/jupyterlab_sql/tests/handlers/test_serializer.py
@@ -48,7 +48,10 @@ def test_serialize_uuid_array():
 
 @pytest.mark.parametrize(
     "test_str",
-    ["3.14", "3.141592653589793238462643383279502884197169399375105820974944592307816"]
+    [
+        "3.14",
+        "3.141592653589793238462643383279502884197169399375105820974944592307816",  # noqa
+    ],
 )
 def test_serialize_decimal(test_str):
     dec = decimal.Decimal(test_str)

--- a/jupyterlab_sql/tests/handlers/test_serializer.py
+++ b/jupyterlab_sql/tests/handlers/test_serializer.py
@@ -46,8 +46,11 @@ def test_serialize_uuid_array():
     assert make_row_serializable(row) == (1, [uuid1_str, uuid2_str])
 
 
-def test_serialize_decimal():
-    expected_str = '3.14'
-    dec = decimal.Decimal(expected_str)
+@pytest.mark.parametrize(
+    "test_str",
+    ["3.14", "3.141592653589793238462643383279502884197169399375105820974944592307816"]
+)
+def test_serialize_decimal(test_str):
+    dec = decimal.Decimal(test_str)
     row = (1, dec)
-    assert make_row_serializable(row) == (1, expected_str)
+    assert make_row_serializable(row) == (1, test_str)

--- a/jupyterlab_sql/tests/handlers/test_serializer.py
+++ b/jupyterlab_sql/tests/handlers/test_serializer.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+import decimal
 
 import pytest
 
@@ -43,3 +44,10 @@ def test_serialize_uuid_array():
     uuid2_str = "bfd96545-bd8b-41bb-b9fc-afb57f7d1328"
     row = (1, [uuid.UUID(uuid1_str), uuid.UUID(uuid2_str)])
     assert make_row_serializable(row) == (1, [uuid1_str, uuid2_str])
+
+
+def test_serialize_decimal():
+    expected_str = '3.14'
+    dec = decimal.Decimal(expected_str)
+    row = (1, dec)
+    assert make_row_serializable(row) == (1, expected_str)


### PR DESCRIPTION
Prior to this PR, columns of type numeric caused the server extension to crash because they are read as decimals, which the `json` module can't serialize directly.

Addresses issue #61 .