### PR TITLE
Fix return in connnection bar

### DIFF
--- a/__tests__/src/services/connectionUrl.test.ts
+++ b/__tests__/src/services/connectionUrl.test.ts
@@ -14,4 +14,12 @@ describe('sanitize', () => {
       )
     ).toEqual('postgres://awsuser:•••••••@some.hostname.com/dbname');
   });
+
+  it('with user without password', () => {
+    expect(
+      ConnectionUrl.sanitize(
+        'postgres://awsuser@some.hostname.com/dbname'
+      )
+    ).toEqual('postgres://awsuser@some.hostname.com/dbname')
+  })
 });

--- a/__tests__/src/services/connectionUrl.test.ts
+++ b/__tests__/src/services/connectionUrl.test.ts
@@ -17,9 +17,7 @@ describe('sanitize', () => {
 
   it('with user without password', () => {
     expect(
-      ConnectionUrl.sanitize(
-        'postgres://awsuser@some.hostname.com/dbname'
-      )
-    ).toEqual('postgres://awsuser@some.hostname.com/dbname')
-  })
+      ConnectionUrl.sanitize('postgres://awsuser@some.hostname.com/dbname')
+    ).toEqual('postgres://awsuser@some.hostname.com/dbname');
+  });
 });

--- a/src/services/connectionUrl.ts
+++ b/src/services/connectionUrl.ts
@@ -3,7 +3,10 @@ import * as urlparse from 'url-parse';
 export namespace ConnectionUrl {
   export function sanitize(url: string): string {
     const parsedUrl = urlparse(url);
-    parsedUrl.set('password', '•••••••');
+    const { password } = parsedUrl;
+    if (password && password !== '') {
+      parsedUrl.set('password', '•••••••');
+    }
     return parsedUrl.href;
   }
 }

--- a/src/toolbar.tsx
+++ b/src/toolbar.tsx
@@ -130,7 +130,7 @@ class ConnectionInformationEdit extends React.Component<
 
   onKeyDown(event: React.KeyboardEvent<HTMLInputElement>): void {
     if (event.key === 'Enter') {
-      this.finish();
+      this.inputRef.current!.blur();
     } else if (event.keyCode === 27) {
       // ESC key
       this.cancel();


### PR DESCRIPTION
Prior to this PR, <return> would replace the password with `*****`. This fixes it.

~Typing return in the connection bar should probably focus the editor?~

Addresses issue #63 .