### PR TITLE
Use jsonschema draft 4 validator

### DIFF
--- a/jupyterlab_sql/schema_loader.py
+++ b/jupyterlab_sql/schema_loader.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from pkg_resources import resource_string
 
-from jsonschema import Draft7Validator as Validator
+from jsonschema import Draft4Validator as Validator
 
 
 SCHEMAS_PATH = Path("schemas")

--- a/jupyterlab_sql/tests/test_request_decoder.py
+++ b/jupyterlab_sql/tests/test_request_decoder.py
@@ -1,6 +1,6 @@
 import json
 
-from jsonschema import Draft7Validator as Validator
+from jsonschema import Draft4Validator as Validator
 
 import pytest
 


### PR DESCRIPTION
This is what is currently used in Jupyter:

https://github.com/jupyter/nbformat/blob/3af03b7804357d967aa035d677c5be64c8a86680/nbformat/validator.py

This should resolve import errors around the Draft7 validator being missing.

Address issue #96  .