### PR TITLE
Catch a missing database with MySQL in the connection string

### DIFF
--- a/jupyterlab_sql/connection_url.py
+++ b/jupyterlab_sql/connection_url.py
@@ -2,10 +2,21 @@ import sqlalchemy.engine.url
 
 
 def is_sqlite(url):
-    backend = sqlalchemy.engine.url.make_url(url).get_backend_name()
+    backend = _to_sqlalchemy_url(url).get_backend_name()
     return backend == "sqlite"
 
 
 def is_mysql(url):
-    backend = sqlalchemy.engine.url.make_url(url).get_backend_name()
+    backend = _to_sqlalchemy_url(url).get_backend_name()
     return backend == "mysql"
+
+
+def has_database(url):
+    database = _to_sqlalchemy_url(url).database
+    # database is either None or an empty string, depending on
+    # whether the URL contains a trailing slash.
+    return bool(database)
+
+
+def _to_sqlalchemy_url(url):
+    return sqlalchemy.engine.url.make_url(url)

--- a/jupyterlab_sql/connection_url.py
+++ b/jupyterlab_sql/connection_url.py
@@ -4,3 +4,8 @@ import sqlalchemy.engine.url
 def is_sqlite(url):
     backend = sqlalchemy.engine.url.make_url(url).get_backend_name()
     return backend == "sqlite"
+
+
+def is_mysql(url):
+    backend = sqlalchemy.engine.url.make_url(url).get_backend_name()
+    return backend == "mysql"

--- a/jupyterlab_sql/executor.py
+++ b/jupyterlab_sql/executor.py
@@ -4,7 +4,11 @@ from sqlalchemy.pool import StaticPool
 
 from .serializer import make_row_serializable
 from .cache import Cache
-from .connection_url import is_sqlite
+from .connection_url import is_sqlite, is_mysql, has_database
+
+
+class InvalidConnectionUrl(Exception):
+    pass
 
 
 class QueryResult:
@@ -28,6 +32,12 @@ class Executor:
         self._sqlite_engine_cache = Cache()
 
     def get_table_names(self, connection_url):
+        if is_mysql(connection_url) and not has_database(connection_url):
+            raise InvalidConnectionUrl(
+                "You need to specify a database name in the connection "
+                "URL for MySQL databases. Use, for instance, "
+                "`mysql://localhost/employees`."
+            )
         engine = self._get_engine(connection_url)
         return engine.table_names()
 

--- a/jupyterlab_sql/tests/test_connection_url.py
+++ b/jupyterlab_sql/tests/test_connection_url.py
@@ -42,3 +42,27 @@ def test_mysql(url):
 )
 def test_not_mysql(url):
     assert not connection_url.is_mysql(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "mysql:///employees",
+        "mysql://localhost/employees",
+        "sqlite:///foo.db"
+    ]
+)
+def test_has_database(url):
+    assert connection_url.has_database(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "mysql://",
+        "mysql://localhost/",
+        "sqlite://"
+    ]
+)
+def test_not_has_database(url):
+    assert not connection_url.has_database(url)

--- a/jupyterlab_sql/tests/test_connection_url.py
+++ b/jupyterlab_sql/tests/test_connection_url.py
@@ -30,8 +30,8 @@ def test_not_sqlite(url):
         "mysql:///employees",
         "mysql://localhost/employees",
         "mysql+mysqldb:///employees",
-        "mysql+pymysql:///employees"
-    ]
+        "mysql+pymysql:///employees",
+    ],
 )
 def test_mysql(url):
     assert connection_url.is_mysql(url)
@@ -46,23 +46,14 @@ def test_not_mysql(url):
 
 @pytest.mark.parametrize(
     "url",
-    [
-        "mysql:///employees",
-        "mysql://localhost/employees",
-        "sqlite:///foo.db"
-    ]
+    ["mysql:///employees", "mysql://localhost/employees", "sqlite:///foo.db"],
 )
 def test_has_database(url):
     assert connection_url.has_database(url)
 
 
 @pytest.mark.parametrize(
-    "url",
-    [
-        "mysql://",
-        "mysql://localhost/",
-        "sqlite://"
-    ]
+    "url", ["mysql://", "mysql://localhost/", "sqlite://"]
 )
 def test_not_has_database(url):
     assert not connection_url.has_database(url)

--- a/jupyterlab_sql/tests/test_connection_url.py
+++ b/jupyterlab_sql/tests/test_connection_url.py
@@ -22,3 +22,23 @@ def test_sqlite(url):
 )
 def test_not_sqlite(url):
     assert not connection_url.is_sqlite(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "mysql:///employees",
+        "mysql://localhost/employees",
+        "mysql+mysqldb:///employees",
+        "mysql+pymysql:///employees"
+    ]
+)
+def test_mysql(url):
+    assert connection_url.is_mysql(url)
+
+
+@pytest.mark.parametrize(
+    "url", ["postgres://localhost:5432/postgres", "sqlite://"]
+)
+def test_not_mysql(url):
+    assert not connection_url.is_mysql(url)


### PR DESCRIPTION
With this PR, if a user tries to query a MySQL database without explicitly specifying a database name in the connection URL, they get an understandable error:

<img width="1080" alt="Screenshot 2019-12-28 at 16 34 27" src="https://user-images.githubusercontent.com/1392879/71546527-b27fbf00-298f-11ea-8001-1d01bd89121f.png">

Prior to this PR, the error was 'NoneType' object has no attribute 'replace'.

Addresses (in part) issue #102.